### PR TITLE
Allow GitHub usernames as port maintainers

### DIFF
--- a/guide/xml/portfile-keywords.xml
+++ b/guide/xml/portfile-keywords.xml
@@ -108,12 +108,14 @@
       <term>maintainers</term>
 
       <listitem>
-        <para>A port's maintainers are the people who have agreed to take
-        responsibility for keeping the port up-to-date. Most ports have only a
-        single maintainer, but some ports have two or more co-maintainers. The
-        <literal>maintainers</literal> keyword lists the maintainers' email
-        addresses, preferably in the obfuscated form which hides them
-        from spambots:</para>
+        <para>
+          A port's maintainers are the people who have agreed to take
+          responsibility for keeping the port up-to-date. Most ports have only
+          a single maintainer, but some ports have two or more co-maintainers.
+          The <literal>maintainers</literal> keyword lists the maintainers'
+          GitHub usernames or email addresses. GitHub usernames start with an
+          <literal>@</literal> symbol. Email addresses are preferably listed in
+          the obfuscated form below to hide them from spambots:</para>
 
         <itemizedlist>
           <listitem>
@@ -128,12 +130,13 @@
           </listitem>
         </itemizedlist>
 
-        <para>In the example below, the maintainer email addresses
-        <email>jdoe@macports.org</email> and
-        <email>julesverne@example.org</email> are hidden using these
-        conventions.</para>
+        <para>In the example below, the port is maintained by a GitHub user
+          named neverpanic, and the owners of the two email addresses
+          <email>jdoe@macports.org</email> and
+          <email>julesverne@example.org</email></para>
 
-        <programlisting>maintainers         jdoe \
+        <programlisting>maintainers         @neverpanic\
+                    jdoe \
                     example.org:julesverne</programlisting>
 
         <note>

--- a/guide/xml/portfiledev.xml
+++ b/guide/xml/portfiledev.xml
@@ -205,17 +205,19 @@
       <listitem>
         <para>Port maintainers</para>
 
-        <para>A port's maintainers are the people who have agreed to take
-        responsibility for keeping the port up-to-date. The
-        <literal>maintainers</literal> keyword lists the maintainers' email
-        addresses, preferably in the obfuscated form which hides them
-        from spambots. For more, see the full explanation of the <link
-        linkend="reference.keywords.maintainers">maintainers keyword</link> in
-        the <link linkend="reference.keywords">Global Keywords</link> section
-        of the <link linkend="reference">Portfile Reference</link>
-        chapter.</para>
+        <para>
+          A port's maintainers are the people who have agreed to take
+          responsibility for keeping the port up-to-date. The
+          <literal>maintainers</literal> keyword lists the maintainers' GitHub
+          usernames or email addresses, preferably in the obfuscated form which
+          hides them from spambots. For more, see the full explanation of the
+          <link linkend="reference.keywords.maintainers">maintainers
+            keyword</link> in the <link linkend="reference.keywords">Global
+            Keywords</link> section of the <link linkend="reference">Portfile
+            Reference</link> chapter.</para>
 
-        <programlisting>maintainers         jdoe \
+        <programlisting>maintainers         @neverpanic \
+                    jdoe \
                     example.org:julesverne</programlisting>
       </listitem>
 

--- a/guide/xml/project.xml
+++ b/guide/xml/project.xml
@@ -239,8 +239,8 @@
               </row>
               <row>
                 <entry><guilabel>Owner</guilabel>/<guilabel>Cc</guilabel></entry>
-                <entry>Full email address of the port's maintainer. Run
-                  <command>port info --maintainer
+                <entry>Full email address or GitHub username of the port's
+                  maintainer. Run <command>port info --maintainer
                     <replaceable>&lt;portname&gt;</replaceable></command> to
                   look this up. Do not add
                   <email>nomaintainer@macports.org</email> or
@@ -434,36 +434,41 @@
         </listitem>
 
         <listitem>
-          <para><guilabel>Cc:</guilabel> Anyone else besides the ticket
-          reporter and assignee who would like to be kept involved in the
-          development of the ticket. Multiple email addresses should be
-          separated with a comma and a space
-          (e.g., <literal>you@example.org, maintainer@macports.org</literal>).</para>
+          <para>
+            <guilabel>Cc:</guilabel> Anyone else besides the ticket reporter
+            and assignee who would like to be kept involved in the development
+            of the ticket. Multiple email addresses or GitHub usernames should
+            be separated with a comma and a space (e.g., <literal>neverpanic,
+              you@example.org, maintainer@macports.org</literal>).</para>
 
-          <para>When reporting port-related tickets, make sure you add the
-          port maintainers email address to the <guilabel>Cc:</guilabel> field
-          so they are notified of the ticket (unless you have commit access,
-          then see <guilabel>Assign To:</guilabel> below). You can obtain the
-          email address of the port maintainer from the Portfile, or by running
-          <literal>port info --maintainers <replaceable>[port]</replaceable>
-          </literal></para>
+          <para>
+            When reporting port-related tickets, make sure you add the port
+            maintainers email address or GitHub username to the
+            <guilabel>Cc:</guilabel> field so they are notified of the ticket
+            (unless you have commit access, then see <guilabel>Assign
+              To:</guilabel> below). You can obtain the email address or GitHub
+            username of the port maintainer by running <command>port info
+              --maintainers <replaceable>[port]</replaceable></command></para>
         </listitem>
 
         <listitem>
-          <para><guilabel>Assign To:</guilabel> Only users with commit access
-          can edit this field. If this is not you, see the section on the
-          <guimenu>Cc</guimenu> field above.</para>
+          <para>
+            <guilabel>Assign To:</guilabel> Only users with commit access can
+            edit this field. If this is not you, see the section on the
+            <guimenu>Cc</guimenu> field above.</para>
 
-          <para>For tickets on ports, enter
-          the email address of the port's maintainer (use <command>port info
-          &lt;portname&gt;</command> to find this). If multiple maintainers
-          are listed, enter the first maintainer's email address here and
-          enter the remaining maintainers' email addresses in the
-          <guimenu>Cc</guimenu> field. Exclude the email address
-          <email>openmaintainer@macports.org</email> if it appears.
-          If the maintainer's email address is
-          <email>nomaintainer@macports.org</email>, leave the field
-          blank.</para>
+          <para>
+            For tickets on ports, enter the email address or GitHub username of
+            the port's maintainer (use <command>port info
+              <replaceable>[port]</replaceable></command> to find this). If
+            multiple maintainers are listed, enter the first maintainer's email
+            address or GitHub username here and enter the remaining
+            maintainers' email addresses or GitHub usernames in the
+            <guimenu>Cc</guimenu> field. Exclude the email address
+            <email>openmaintainer@macports.org</email> if it appears. If the
+            maintainer's email address is
+            <email>nomaintainer@macports.org</email>, leave the field
+            blank.</para>
         </listitem>
 
         <listitem>
@@ -584,7 +589,8 @@
         </listitem>
 
         <listitem>
-          <para>Put the maintainer's email address into the
+          <para>
+            Put the maintainer's email address or GitHub username into the
             <guilabel>Cc</guilabel> field. You can use
             <programlisting><prompt>%%</prompt> <userinput>port info --maintainer $portname</userinput></programlisting>
             where <userinput>$portname</userinput> is the name of the port you
@@ -617,7 +623,7 @@
 
       <itemizedlist>
         <listitem>
-          <para>An email address.</para>
+          <para>An email address or a GitHub account.</para>
         </listitem>
         <listitem>
           <para>A copy of the <filename>Portfile</filename>. Do not worry if
@@ -735,7 +741,9 @@ To use the current port, you must be in a port's directory.</screen>
           <para>Open the <filename>Portfile</filename> in your favorite editor
             and look for the line that starts with <option>maintainer</option>.
             Delete <option>nomaintainer</option> from the line if it exists and
-            add your own email address in the form
+            add your own GitHub username or email address. For GitHub
+            usernames, prefix your username with an <literal>@</literal> sign.
+            Email addresses should be written in the form
             <userinput>domain.tld:localpart</userinput>. The address is
             obfuscated to prevent email harvesters from automatically grabbing
             your address. If you want, you can start fixing bugs in the
@@ -771,7 +779,7 @@ To use the current port, you must be in a port's directory.</screen>
 
           <para>Finally, run <userinput>port info</userinput> again. The
             maintainers line in the output should now contain your email
-            address.</para>
+            address or GitHub username.</para>
 
           <note>
             <para>If you made changes other than the maintainer line, you might


### PR DESCRIPTION
After the move to GitHub, it is sometimes difficult to figure out
whether a pull request was sent or a ticket was opened by a maintainer,
because both these systems use GitHub usernames now.

This leads to more confusion with developers and users than needed.
Change the documentation to allow GitHub usernames as maintainers for
Portfiles to avoid this.

Using a GitHub username leaves us with the problem that there is no
email address available for this user, unless the user has added
a public email address to their GitHub account. Email addresses are
instead available in commits, and maintainers can always be reached by
ticket or GitHub comment.