### PR TITLE
Remove reference to BSD Unix

### DIFF
--- a/guide/xml/glossary.xml
+++ b/guide/xml/glossary.xml
@@ -45,14 +45,6 @@
       </glossentry>
 
       <glossentry>
-        <glossterm>BSD Unix</glossterm>
-
-        <glossdef>
-          <para />
-        </glossdef>
-      </glossentry>
-
-      <glossentry>
         <glossterm>destroot phase</glossterm>
 
         <glossdef>


### PR DESCRIPTION
BSD Unix is not referenced in the guide