### PR TITLE
Prefer dashes instead of periods (- > .) for id

### DIFF
--- a/guide/xml/intro.xml
+++ b/guide/xml/intro.xml
@@ -9,7 +9,7 @@
     <para>MacPorts is an easy to use system for compiling, installing, and managing open source software. MacPorts may
         be conceptually divided into two main parts: the infrastructure, known as MacPorts base, and the set of
         available ports. A MacPorts port is a set of specifications contained in a <link
-            linkend="development.introduction">Portfile</link> that defines an application, its characteristics, and any
+            linkend="development-introduction">Portfile</link> that defines an application, its characteristics, and any
         files or special instructions required to install it. This allows you to use a single command to tell MacPorts
         to automatically download, compile, and install applications and libraries. But using MacPorts to manage your
         open source software provides several other significant advantages. For example, MacPorts:</para>

--- a/guide/xml/portfile-phase.xml
+++ b/guide/xml/portfile-phase.xml
@@ -13,8 +13,8 @@
     <command>configure</command>, <command>make</command>, and <command>make
     install</command> steps. For applications that do not conform to this
     standard, installation phases may be declared in a Portfile to <link
-    linkend="development.examples.augment">augment</link> or <link
-    linkend="development.examples.override">override</link> the default
+    linkend="development-examples-augment">augment</link> or <link
+    linkend="development-examples.override">override</link> the default
     behavior as described in the <link linkend="development">Portfile
     Development</link> chapter.</para>
 

--- a/guide/xml/portfiledev.xml
+++ b/guide/xml/portfiledev.xml
@@ -19,7 +19,7 @@
   within. The only required file in a port is the
   <filename>Portfile</filename>.</para>
 
-  <section xml:id="development.introduction">
+  <section xml:id="development-introduction">
     <title>Portfile Introduction</title>
 
     <para>A MacPorts Portfile is a <link
@@ -78,10 +78,10 @@
     install</command> steps, which conform to phases configure, build, and
     destroot respectively. For applications that do not conform to this
     standard behavior, any installation phase may be augmented using <link
-    linkend="development.examples.augment">pre- and/or post- phases</link>, or
-    even <link linkend="development.examples.override">overridden</link> or
-    <link linkend="development.examples.eliminate">eliminated</link>. See
-    <link linkend="development.examples">Example Portfiles</link>
+    linkend="development-examples-augment">pre- and/or post- phases</link>, or
+    even <link linkend="development-examples.override">overridden</link> or
+    <link linkend="development-examples.eliminate">eliminated</link>. See
+    <link linkend="development-examples">Example Portfiles</link>
     below.</para>
 
     <note>
@@ -90,7 +90,7 @@
     </note>
   </section>
 
-  <section xml:id="development.creating-portfile">
+  <section xml:id="development-creating-portfile">
     <title>Creating a Portfile</title>
 
     <para>Here we list the individual Portfile components for an application
@@ -104,7 +104,7 @@
 
         <para>This should be the first line of a Portfile. It sets the correct
         editing options for vim and emacs. See <link
-        linkend="development.practices.portstyle">Port Style</link> for more
+        linkend="development-practices.portstyle">Port Style</link> for more
         information. Its use is optional and up to the port maintainer.</para>
 
         <programlisting># -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4</programlisting>
@@ -302,19 +302,19 @@ Error: Processing of port rrdtool failed</screen>
     </orderedlist>
   </section>
 
-  <section xml:id="development.examples">
+  <section xml:id="development-examples">
     <title>Example Portfiles</title>
 
     <para>In this section we begin by taking a look at a complete simple
     Portfile; then we see how to <link
-    linkend="development.examples.augment">augment default phases</link> by
+    linkend="development-examples-augment">augment default phases</link> by
     defining pre- and post- phases, how to <link
-    linkend="development.examples.override">override default phases</link>,
+    linkend="development-examples.override">override default phases</link>,
     and finally how to <link
-    linkend="development.examples.eliminate">eliminate port
+    linkend="development-examples.eliminate">eliminate port
     phases</link>.</para>
 
-    <section xml:id="development.examples.basic">
+    <section xml:id="development-examples.basic">
       <title>A Basic Portfile</title>
 
       <programlisting># -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
@@ -344,7 +344,7 @@ configure.args      --enable-perl-site-install \
                     --mandir=${prefix}/share/man</programlisting>
     </section>
 
-    <section xml:id="development.examples.augment">
+    <section xml:id="development-examples-augment">
       <title>Augment Phases Using pre- / post-</title>
 
       <para>To augment a port's installation phase, and not override it, you
@@ -359,7 +359,7 @@ configure.args      --enable-perl-site-install \
 }</programlisting>
     </section>
 
-    <section xml:id="development.examples.override">
+    <section xml:id="development-examples.override">
       <title>Overriding Phases</title>
 
       <para>To override the automatic MacPorts installation phase processing,
@@ -371,7 +371,7 @@ configure.args      --enable-perl-site-install \
 }</programlisting>
     </section>
 
-    <section xml:id="development.examples.eliminate">
+    <section xml:id="development-examples.eliminate">
       <title>Eliminating Phases</title>
 
       <para>To eliminate a default phase, simply define a phase with no
@@ -389,7 +389,7 @@ configure.args      --enable-perl-site-install \
       </note>
     </section>
 
-    <section xml:id="development.examples.startupitem">
+    <section xml:id="development-examples.startupitem">
       <title>Creating a StartupItem</title>
 
       <para>Startupitems may be placed in the global section of a
@@ -401,7 +401,7 @@ startupitem.executable  "${prefix}/bin/nmicmpd"</programlisting>
     </section>
   </section>
 
-  <section xml:id="development.variants">
+  <section xml:id="development-variants">
     <title>Port Variants</title>
 
     <para>Variants are a way for port authors to provide options that may be
@@ -410,7 +410,7 @@ startupitem.executable  "${prefix}/bin/nmicmpd"</programlisting>
     linkend="reference.variants.descriptions">carefully chosen variant
     descriptions</link>.</para>
 
-    <section xml:id="development.variants.options">
+    <section xml:id="development-variants.options">
       <title>Example Variants</title>
 
       <para>The most common actions for user-selected variants is to add or
@@ -472,7 +472,7 @@ variant sqlite description {Build sqlite support} {
 }</programlisting>
     </section>
 
-    <section xml:id="development.variants.phase">
+    <section xml:id="development-variants.phase">
       <title>Variant Actions in a Phase</title>
 
       <para>If a variant requires options in addition to those provided by
@@ -494,7 +494,7 @@ variant sqlite description {Build sqlite support} {
 }</programlisting>
     </section>
 
-    <section xml:id="development.variants.default">
+    <section xml:id="development-variants.default">
       <title>Default Variants</title>
 
       <para>Variants are used to specify actions that lie outside the core
@@ -513,7 +513,7 @@ variant sqlite description {Build sqlite support} {
     </section>
   </section>
 
-  <section xml:id="development.patches">
+  <section xml:id="development-patches">
     <title>Patch Files</title>
 
     <para>Patch files are files created with the Unix command
@@ -521,7 +521,7 @@ variant sqlite description {Build sqlite support} {
     <command>patch</command> to modify text files to fix bugs or extend
     functionality.</para>
 
-    <section xml:id="development.patches.portfile">
+    <section xml:id="development-patches.portfile">
       <title>Creating Portfile Patches</title>
 
       <para>If you wish to contribute modifications or fixes to a Portfile,
@@ -584,7 +584,7 @@ variant sqlite description {Build sqlite support} {
       the port author to evaluate.</para>
     </section>
 
-    <section xml:id="development.patches.source">
+    <section xml:id="development-patches.source">
       <title>Creating Source Code Patches</title>
 
       <para>Necessary or useful patches to application source code should
@@ -696,7 +696,7 @@ variant sqlite description {Build sqlite support} {
       </orderedlist>
     </section>
 
-    <section xml:id="development.patches.applying">
+    <section xml:id="development-patches.applying">
       <title>Manually Applying Patches</title>
 
       <para>MacPorts applies patch files automatically, but you may want to
@@ -725,7 +725,7 @@ variant sqlite description {Build sqlite support} {
     </section>
   </section>
 
-  <section xml:id="development.local-repositories">
+  <section xml:id="development-local-repositories">
     <title>Local Portfile Repositories</title>
 
     <para>To create and test Portfiles that are not yet published in the MacPorts ports tree,
@@ -779,7 +779,7 @@ rsync://rsync.macports.org/release/ports [default]
         files, create a <filename>files</filename> directory and place the
         patchfiles in it, and reference the patchfiles in your Portfile, as
         explained in
-        <link linkend="development.patches.source">Creating Source Code Patches</link>.</para>
+        <link linkend="development-patches.source">Creating Source Code Patches</link>.</para>
       </listitem>
 
       <listitem>
@@ -810,14 +810,14 @@ Ports failed:                   0</screen>
     The Best Ever Game</screen>
   </section>
 
-  <section xml:id="development.practices">
+  <section xml:id="development-practices">
     <title>Portfile Best Practices</title>
 
     <para>This section contains practical guidelines for creating Portfiles
     that install smoothly and provide consistency between ports. The following
     sections are on the TODO list.</para>
 
-    <section xml:id="development.practices.portstyle">
+    <section xml:id="development-practices.portstyle">
       <title>Port Style</title>
 
       <para>Portfiles may be thought of as a set of declarations rather than
@@ -873,25 +873,25 @@ Ports failed:                   0</screen>
                      ${destroot}${prefix}/var/cache/mrtg</programlisting>
     </section>
 
-    <section xml:id="development.practices.dont-overwrite">
+    <section xml:id="development-practices.dont-overwrite">
       <title>Don't Overwrite Config Files</title>
 
       <para>TODO:</para>
     </section>
 
-    <section xml:id="development.practices.install-docs">
+    <section xml:id="development-practices.install-docs">
       <title>Install Docs and Examples</title>
 
       <para>TODO:</para>
     </section>
 
-    <section xml:id="development.practices.provide-messages">
+    <section xml:id="development-practices.provide-messages">
       <title>Provide User Messages</title>
 
       <para>TODO:</para>
     </section>
 
-    <section xml:id="development.practices.use-variables">
+    <section xml:id="development-practices.use-variables">
       <title>Use Variables</title>
 
       <para>TODO: Set variables so changing paths may be done in one place;
@@ -900,7 +900,7 @@ Ports failed:                   0</screen>
     </section>
 
 
-    <section xml:id="development.practices.rename-replace-port">
+    <section xml:id="development-practices-rename-replace-port">
       <title>Renaming or replacing a port</title>
 
       <para>If there is the need to replace a port with another port or a
@@ -916,7 +916,7 @@ Ports failed:                   0</screen>
       <para>At the end of this section the use of the obsolete PortGroup is suggested
       as an even shorter approach to the below described workflow.</para>
 
-      <section xml:id="development.replaced_by">
+      <section xml:id="development-replaced_by">
         <title>The long way</title>
 
         <para>Skrooge's original devel port file looked like this:</para>
@@ -1087,7 +1087,7 @@ To report a bug, see &lt;http://guide.macports.org/#project.tickets&gt;</screen>
 
       </section>
 
-      <section xml:id="development.obsolete-portgroup">
+      <section xml:id="development-obsolete-portgroup">
         <title>The shortcut: PortGroup obsolete</title>
 
         <para>Using the PortGroup obsolete makes the task described in the previous subsection
@@ -1121,12 +1121,12 @@ categories          kde finance
 
     </section>
 
-    <section xml:id="development.practices.removing-port">
+    <section xml:id="development-practices.removing-port">
       <title>Removing a port</title>
 
       <para>If a port has to be removed from MacPorts one should consider
         the hints concerning replacing it by some alternative port given
-        <link linkend="development.practices.rename-replace-port">above</link>.
+        <link linkend="development-practices-rename-replace-port">above</link>.
         It is recommended to wait one year before the port directory
         is actually removed from the MacPorts ports tree.
       </para>
@@ -1138,7 +1138,7 @@ categories          kde finance
 
   </section>
 
-  <section xml:id="development.buildbot">
+  <section xml:id="development-buildbot">
     <title>MacPorts' buildbot</title>
 
     <para>The <link xlink:href="https://build.macports.org/">buildbot</link> is a port


### PR DESCRIPTION
Dots have special meaning in xml:id/linkend so avoid warnings
by using dashes instead.