### PR TITLE
The 'new' and 'update' port references to GitHub were transposed.

### DIFF
--- a/guide/xml/project.xml
+++ b/guide/xml/project.xml
@@ -541,7 +541,7 @@
         </listitem>
 
         <listitem>
-          <para>... or submit the port update through a pull request on GitHub.</para>
+          <para>... or submit the new port through a pull request on GitHub.</para>
         </listitem>
 
         <listitem>
@@ -614,7 +614,7 @@
         </listitem>
 
         <listitem>
-          <para>... or submit the new port through a pull request on GitHub.</para>
+          <para>... or submit the port update through a pull request on GitHub.</para>
         </listitem>
 
         <listitem>


### PR DESCRIPTION
Re sections 7.2.1, "New Ports" and 7.2.2 "Port Enhancements"
