### PR TITLE
Makefile: Switch to docbook-xsl-ns for DocBook 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ addons:
     packages:
     - libxml2-utils
     - xsltproc
-    - docbook-xsl
+    - docbook-xsl-ns
     - docbook5-xml
 
 script: |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ DocBook XML sources to the desired output format. You can install them from
 MacPorts with this command:
 
 ```
-$ sudo port install libxml2 libxslt docbook-xsl docbook-xml-5.0
+$ sudo port install libxml2 libxslt docbook-xsl-ns docbook-xml-5.0
 ```
 
 ### HTML Output

--- a/guide/resources/chunk.xsl
+++ b/guide/resources/chunk.xsl
@@ -1,5 +1,5 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version='1.0'>
-    <xsl:import href="http://docbook.sourceforge.net/release/xsl/current/xhtml/chunk.xsl"/>
+    <xsl:import href="http://docbook.sourceforge.net/release/xsl-ns/current/xhtml/chunk.xsl"/>
     <xsl:include href="base.xsl"/>
     <!-- Include tab switching for chunk and single-page -->
     <xsl:include href="tabs.xsl"/>

--- a/guide/resources/single-page.xsl
+++ b/guide/resources/single-page.xsl
@@ -1,5 +1,5 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version='1.0'>
-    <xsl:import href="http://docbook.sourceforge.net/release/xsl/current/xhtml/profile-docbook.xsl"/>
+    <xsl:import href="http://docbook.sourceforge.net/release/xsl-ns/current/xhtml/profile-docbook.xsl"/>
     <xsl:include href="base.xsl"/>
     <!-- Include tab switching for chunk and single-page -->
     <xsl:include href="tabs.xsl"/>


### PR DESCRIPTION
With the switch to DocBook 5.0, the DocBook XSL stylesheets should have
been switched to the [namespaced variant][1]. However, at that time, the
docbook-xsl port already provided the namespaced version due to
a [mistake][2]. While namespace stripping seems to work, explicitly
switch to docbook-xsl-ns now.

Please do not merge this until the docbook-xsl-ns port has been installed on the buildbot.
See: https://trac.macports.org/ticket/56397

[1]: https://docbook.org/docs/howto/howto.html#processing
[2]: https://trac.macports.org/ticket/55946