### PR TITLE
Add macOS 10.14 Mojave link and example

### DIFF
--- a/guide/xml/installing.xml
+++ b/guide/xml/installing.xml
@@ -165,6 +165,14 @@
                     <variablelist>
                         <varlistentry>
                             <term>
+                                macOS 10.14 Mojave:
+                            </term>
+                            <listitem>
+                                <para><link xlink:href="https://github.com/macports/macports-base/releases/download/v&macports-version;/MacPorts-&macports-version;-10.14-Mojave.pkg">MacPorts-&macports-version;-10.14-Mojave.pkg</link></para>
+                            </listitem>
+                        </varlistentry>
+                        <varlistentry>
+                            <term>
                                 macOS 10.13 High Sierra:
                             </term>
                             <listitem>
@@ -177,14 +185,6 @@
                             </term>
                             <listitem>
                                 <para><link xlink:href="https://github.com/macports/macports-base/releases/download/v&macports-version;/MacPorts-&macports-version;-10.12-Sierra.pkg">MacPorts-&macports-version;-10.12-Sierra.pkg</link></para>
-                            </listitem>
-                        </varlistentry>
-                        <varlistentry>
-                            <term>
-                                OS X 10.11 El Capitan:
-                            </term>
-                            <listitem>
-                                <para><link xlink:href="https://github.com/macports/macports-base/releases/download/v&macports-version;/MacPorts-&macports-version;-10.11-ElCapitan.pkg">MacPorts-&macports-version;-10.11-ElCapitan.pkg</link></para>
                             </listitem>
                         </varlistentry>
                     </variablelist>

--- a/guide/xml/portfile-variants.xml
+++ b/guide/xml/portfile-variants.xml
@@ -171,9 +171,9 @@
           different tasks depending on the version of Darwin, the core
           operating system underlying macOS.
           <replaceable>version</replaceable> is the major version of Darwin,
-          and can be <literal>17</literal> for macOS High Sierra v10.13,
-          <literal>16</literal> for macOS Sierra v10.12, <literal>15</literal>
-          for OS X El Capitan v10.11, and so on.</para>
+          and can be <literal>18</literal> for macOS Mojave 10.14,
+          <literal>17</literal> for macOS High Sierra 10.13, <literal>16</literal>
+          for macOS Sierra 10.12, and so on.</para>
 
           <itemizedlist>
             <listitem>


### PR DESCRIPTION
Q: Should OS X 10.11 El Capitan be removed at this time?