### PR TITLE
Add documentation for the Github portgroup option "github.tarball_from archive"

### DIFF
--- a/guide/xml/portgroup-github.xml
+++ b/guide/xml/portgroup-github.xml
@@ -174,6 +174,21 @@ github.tarball_from downloads</programlisting>
     </para>
   </section>
 
+  <section xml:id="reference.portgroup.github.archive">
+    <title>Distfile from GitHub archive downloads</title>
+
+    <para>
+      Further still, many Github projects have automatically-generated archive
+      URLs that can be used for downloading distfiles.  This can be enabled via
+      <code>archive</code> as follows:
+
+      <programlisting>
+github.tarball_from archive</programlisting>
+
+    </para>
+  </section>
+
+
   <section xml:id="reference.portgroup.github.submodule">
     <title>Using repositories with git submodules</title>
 


### PR DESCRIPTION
Documentation update for the change proposed in macports/macports-ports#2587