### PR TITLE
pdf: fix build error due to t-comma in last name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ guide-dblatex: SUFFIX = pdf
 guide-dblatex:
 	$(MKDIR) -p $(GUIDE_RESULT_DBLATEX)
 	$(DBLATEX) \
+		-P "latex.encoding=utf8" \
 		--fig-path="$(GUIDE)/resources/images" \
 		--type="$(SUFFIX)" \
 		--param='toc.section.depth=2' \

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ In addition to the dependencies listed above, the PDF output format also
 requires the `dblatex` port.
 
 ```
-$ sudo port install dblatex
+$ sudo port install texlive-lang-cyrillic dblatex
 ```
 
 To generate a PDF version of the guide, use `make guide-dblatex`.


### PR DESCRIPTION
Force utf8 encoding and additional port texlive-lang-cyrillic to be
installed for t-comma.

closes https://trac.macports.org/ticket/56123