### PR TITLE
Python PortGroup: update versions and test phase suggestions

### DIFF
--- a/guide/xml/portgroup-python.xml
+++ b/guide/xml/portgroup-python.xml
@@ -23,15 +23,15 @@
           <para>Defines the python versions supported by this port. If the
           port name starts with <quote>py-</quote>, then a subport will be defined for each
           version in the list. For example, if a port named <quote>py-foo</quote> declares
-          <code>python.versions 26 27</code>, subports <quote>py26-foo</quote> and <quote>py27-foo</quote> will be
-          created, and will depend on python26 and python27 respectively.</para>
+          <code>python.versions 36 37</code>, subports <quote>py36-foo</quote> and <quote>py37-foo</quote> will be
+          created, and will depend on python36 and python37 respectively.</para>
           <para>If the port name does not start with <quote>py-</quote>, it is interpreted
           as an application written in python rather than a python module. In
           this case, no subports are defined, and <code>python.versions</code> defaults to
           the value of <code>python.default_version</code>, which must be set. For example,
-          if a port named <quote>mercurial</quote> sets <code>python.default_version 27</code>, then
-          <code>python.versions</code> will automatically be set to <quote>27</quote>, and a dependency
-          on python27 will be added.</para>
+          if a port named <quote>mercurial</quote> sets <code>python.default_version 37</code>, then
+          <code>python.versions</code> will automatically be set to <quote>37</quote>, and a dependency
+          on python37 will be added.</para>
 
           <itemizedlist>
             <listitem>
@@ -40,7 +40,7 @@
             <listitem>
               <para>Example:</para>
 
-              <programlisting>python.versions     25 26 27</programlisting>
+              <programlisting>python.versions     36 37 38</programlisting>
             </listitem>
           </itemizedlist>
         </listitem>
@@ -51,7 +51,7 @@
         <listitem>
           <para>For modules (i.e., name starts with <quote>py-</quote>), this sets the
           subport that will be installed if the user asks to install <quote>py-foo</quote>
-          rather than, e.g., <quote>py26-foo</quote> or <quote>py27-foo</quote>. If not explicitly set, a
+          rather than, e.g., <quote>py36-foo</quote> or <quote>py37-foo</quote>. If not explicitly set, a
           reasonable default is chosen from the list in <code>python.versions</code>.</para>
           <para>For applications (i.e., name does not start with <quote>py-</quote>), this chooses
           which version of python to use, and must be set. It can be changed
@@ -64,7 +64,7 @@
             <listitem>
               <para>Example:</para>
 
-              <programlisting>python.default_version     32</programlisting>
+              <programlisting>python.default_version     36</programlisting>
             </listitem>
           </itemizedlist>
         </listitem>
@@ -152,8 +152,8 @@
 
         <listitem>
           <para>The python version in use in the current subport, in normal
-          dotted notation. For example, if <code>python.version</code> is <quote>26</quote>,
-          <code>python.branch</code> will be <quote>2.6</quote>.</para>
+          dotted notation. For example, if <code>python.version</code> is <quote>36</quote>,
+          <code>python.branch</code> will be <quote>3.6</quote>.</para>
         </listitem>
       </varlistentry>
 
@@ -181,7 +181,7 @@
         <listitem>
           <para>The Python dynamic library path, i.e.,
           <filename>${python.prefix}/Python</filename> (framework builds) or
-          <filename>${prefix}/lib/libpython2.4.dylib</filename> (python24).</para>
+          <filename>${prefix}/lib/libpython3.6.dylib</filename> (python36).</para>
         </listitem>
       </varlistentry>
 
@@ -285,5 +285,22 @@
         </listitem>
       </varlistentry>
     </variablelist>
+  </section>
+  <section xml:id="reference.portgroup.python.test">
+    <title>python Port test tips</title>
+
+    <para>To add a test import of the built package, the following template may be useful</para>
+
+    <programlisting>if {${name} ne ${subport}} {
+<!--     -->
+<!--     -->    pre-test {
+<!--     -->        test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
+<!--     -->    }
+<!--     -->
+<!--     -->    test.run        yes
+<!--     -->    test.cmd        ${python.bin} -c '${python.rootname}'
+<!--     -->    test.target
+<!--     -->
+<!--     -->}</programlisting>
   </section>
 </section>

--- a/guide/xml/portgroup-python.xml
+++ b/guide/xml/portgroup-python.xml
@@ -287,9 +287,9 @@
     </variablelist>
   </section>
   <section xml:id="reference.portgroup.python.test">
-    <title>python Port test tips</title>
+    <title>python PortGroup test tips</title>
 
-    <para>To add a test import of the built package, the following template may be useful</para>
+    <para> If the python package has some unit tests, then the following template may be useful.</para>
 
     <programlisting>if {${name} ne ${subport}} {
 <!--     -->
@@ -298,7 +298,21 @@
 <!--     -->    }
 <!--     -->
 <!--     -->    test.run        yes
-<!--     -->    test.cmd        ${python.bin} -c '${python.rootname}'
+<!--     -->    test.cmd        ${build.cmd}
+<!--     -->    test.target     test
+<!--     -->
+<!--     -->}</programlisting>
+
+    <para>To simply add a test import of the built package, the following template may be useful.</para>
+
+    <programlisting>if {${name} ne ${subport}} {
+<!--     -->
+<!--     -->    pre-test {
+<!--     -->        test.env    PYTHONPATH=[glob -nocomplain ${worksrcpath}/build/lib*]
+<!--     -->    }
+<!--     -->
+<!--     -->    test.run        yes
+<!--     -->    test.cmd        ${python.bin} -c 'import ${python.rootname}'
 <!--     -->    test.target
 <!--     -->
 <!--     -->}</programlisting>


### PR DESCRIPTION
My original purpose of making changes here was to publicize the comments of @reneeotten of https://github.com/macports/macports-ports/pull/6479#issuecomment-592492396
regarding the best way to do a python package import test.  Along the way, I also saw that there were a lot of python version 2 references, and converted these to python version 3 references.  If there is a better place to put the testing information, I am open to suggestions.