### PR TITLE
Update list of ports required to build documentation

### DIFF
--- a/guide/adoc/project.adoc
+++ b/guide/adoc/project.adoc
@@ -563,7 +563,7 @@ $ git remote add username https://github.com/username/macports-guide.git
 
 [source]
 ----
-$ sudo port install libxslt docbook-xsl
+$ sudo port install libxml2 libxslt docbook-xsl-ns docbook-xml-5.0
 ----
 
 


### PR DESCRIPTION
In the Guide, 7.5. "Updating Documentation", 7.5.1.1 "Preparing Changes", there is a step to install the required ports:
* The list of ports currently reads `libxslt docbook-xsl`. But the `README.md` file in the Guide repo's root has a longer list of ports to install, `libxml2 libxslt docbook-xsl-ns docbook-xml-5.0`.
* Also `docbook-xsl` is an obsolete port, so one can't install it anyway.

This changes the step to install required ports, in 7.5.1.1 "Preparing Changes", to match the list of ports from `README.md`.

As far as I can tell, there is no ticket in Trac documenting this problem with the Guide.