### PR TITLE
Describe GitHub changeset links in 7.1.3 Trac Ticket Guidelines

### DIFF
--- a/guide/adoc/project.adoc
+++ b/guide/adoc/project.adoc
@@ -87,8 +87,10 @@ Please see below for longer and more detailed explanations.
                   Describe your problem. Preformatted text (such as terminal
                   output) should be put in ``+{{{``+three curly
                       brackets+``}}}+``. Please attach large
-                  amounts of output rather than pasting. Use the preview
-                  button! 
+                  amounts of output rather than pasting. 
+                  Link to GitHub commits with links like 
+                  ``[changeset:``bd5d680…``/macports-ports`` commit bd5d680``]``.
+                  Use the preview button! 
 
 |**Type**
 |
@@ -182,8 +184,19 @@ There are certain conventions used to ensure that Trac tickets convey as much ac
 
 * *Summary:*``+[port]+````+[version]+````+[concise description]+``
 ** Example: "rrdtool @1.2.23 +python Configure error - build failure"
-* *Description:* All details that might be relevant to someone reading the ticket. Be sure to mention the versions of your operating system and Xcode install. https://trac.macports.org/wiki/WikiFormatting[Wiki formatting] should be used to ensure that text is formatted correctly. Use the Preview button before submitting. If you want to post preformatted text such as a log or terminal output, make sure you use `+{{{``+$$...$$+``}}}+` around the text or it could break the page layout. Example:
-
+* *Description:* All details that might be relevant to someone reading the ticket. Be sure to mention the versions of your operating system and Xcode install. 
+** Use https://trac.macports.org/wiki/WikiFormatting[Wiki formatting] to ensure that text is formatted correctly. 
+Link to GitHub commits with ``[changeset:``GithubSHA``/macports-ports``
+optional link text``]``. 
+For example, for a GitHub commit with URL 
+https://github.com/macports/macports-ports/commit/bd5d6800828a3dcda1b65f3999fa748a365b168e, 
+put ``[changeset:bd5d6800828a3dcda1b65f3999fa748a365b168e/macports-ports
+commit bd5d680]`` in the description. It becomes the link,  
+https://trac.macports.org/changeset/bd5d6800828a3dcda1b65f3999fa748a365b168e/macports-ports[commit bd5d680]. See 
+https://trac.macports.org/wiki/TracLinks#LinkstoMacPortsonGitHub[TracLinks#LinkstoMacPortsonGitHub] for details.
++
+** Use the Preview button before submitting. If you want to post preformatted text such as a log or terminal output, make sure you use `+{{{``+$$...$$+``}}}+` around the text or it could break the page layout. Example:
++
 ....
 
 {{{

--- a/guide/xml/project.xml
+++ b/guide/xml/project.xml
@@ -144,8 +144,11 @@
                   Describe your problem. Preformatted text (such as terminal
                   output) should be put in <literal>{{{<replaceable>three curly
                       brackets</replaceable>}}}</literal>. Please attach large
-                  amounts of output rather than pasting. Use the preview
-                  button!
+                  amounts of output rather than pasting. 
+                  Link to GitHub commits with links like
+                  <literal>[changeset:<replaceable>bd5d680…</replaceable>/macports-ports
+                  <replaceable>commit bd5d680</replaceable>]</literal>.
+                  Use the preview button!
                 </entry>
               </row>
               <row>
@@ -277,10 +280,25 @@
         <listitem>
           <para><emphasis role="strong">Description:</emphasis> All details that might
           be relevant to someone reading the ticket. Be sure to mention
-          the versions of your operating system and Xcode install. <link
+          the versions of your operating system and Xcode install. </para>
+          
+          <para>Use <link
           xlink:href="https://trac.macports.org/wiki/WikiFormatting">Wiki
-          formatting</link> should be used to ensure that text is formatted
-          correctly. Use the Preview button before submitting. If you want to
+          formatting</link> to ensure that text is formatted correctly. 
+          Link to GitHub commits with 
+          <literal>[changeset:<replaceable>GithubSHA</replaceable>/macports-ports 
+          <replaceable>optional link text</replaceable>]</literal>. 
+          For example, for a GitHub commit with URL 
+          <link xlink:href="https://github.com/macports/macports-ports/commit/bd5d6800828a3dcda1b65f3999fa748a365b168e">
+          https://github.com/macports/macports-ports/commit/bd5d6800828a3dcda1b65f3999fa748a365b168e</link>, 
+          put <literal>[changeset:bd5d6800828a3dcda1b65f3999fa748a365b168e/macports-ports
+          commit bd5d680]</literal> in the description. It becomes the link,  
+          <link xlink:href="https://trac.macports.org/changeset/bd5d6800828a3dcda1b65f3999fa748a365b168e/macports-ports">
+          commit bd5d680</link>. See <link 
+          xlink:href="https://trac.macports.org/wiki/TracLinks#LinkstoMacPortsonGitHub">
+          TracLinks#LinkstoMacPortsonGitHub</link> for details.</para>
+          
+          <para>Use the Preview button before submitting. If you want to
           post preformatted text such as a log or terminal output, make sure
           you use <literal>{{{<replaceable>...</replaceable>}}}</literal>
           around the text or it could break the page layout. Example:</para>


### PR DESCRIPTION
Describe the use of Trac changeset links, with a GitHub commit SHA and repository name, as the preferred way to link to a commit in the MacPorts repositories in GitHub.

There is a one-sentence summary in the TL;DR section, followed by a one-paragraph explanation in the "Description" bullet item below. There is a link to TracLinks#LinkstoMacPortsonGitHub in the wiki for the full explanation.

Also, break the "Description" bullet item into two sub-bullets, because there is a bit too much to read comfortably in one paragraph.

Change applied to the DocBook sources in `guide/xml/project.xml`, and corresponding change applied to the `adoc` sources in `guide/adoc/project.adoc`.