### PR TITLE
Update copyright year to 2021

### DIFF
--- a/guide/xml/guide.xml
+++ b/guide/xml/guide.xml
@@ -37,7 +37,7 @@
         </authorgroup>
 
         <copyright>
-            <year>2007–2018</year>
+            <year>2007–2021</year>
             <holder>The MacPorts Project</holder>
         </copyright>
 


### PR DESCRIPTION
Simple bump of copyright year from 2018 to 2021.