### PR TITLE
Add info on https://ports.macports.org to buildbot section, #63001

### DIFF
--- a/guide/adoc/portfiledev.adoc
+++ b/guide/adoc/portfiledev.adoc
@@ -968,7 +968,16 @@ See the https://build.macports.org/builders[list
         of builders] to find out which platforms these currently are.
 
 If a build error occurred for a port its maintainer will be informed via an email so that problems which did not surface on the maintainer's machine will not go unnoticed.
-Port maintainers will find the https://build.macports.org/waterfall[waterfall] and the https://build.macports.org/builders[builders] views most useful since they give information about the build status and offer the possibility to build one's port(s) on specific builders.
 
 Thus the buildbot helps to keep MacPorts consistent on various macOS versions, i.e., a maintainer does not need access to these versions anymore in order to assure that the port(s) maintained build without problems.
 Currently only the default port variants will be built and kept.
+
+The web page at https://build.macports.org/[build.macports.org] offers several views of the recent builds and of their success.
+Port maintainers will find the https://build.macports.org/waterfall[waterfall] and the https://build.macports.org/builders[builders] views most useful since they give information about the build status and offer the possibility to build one's port(s) on specific builders.
+
+Also, a web page at https://ports.macports.org/[ports.macports.org] provides an alternate view of buildbot activity. 
+Enter the name of the port you are interested in. 
+That takes you to a summary page, which shows the success or failure of the last recorded build on each OS version. 
+See the "Port Health" indicators near the top.
+Click on those indicators to to see a description of the latest build on build.macports.org. 
+Click the Build Information tab to see all recorded builds.

--- a/guide/xml/portfiledev.xml
+++ b/guide/xml/portfiledev.xml
@@ -1146,20 +1146,36 @@ categories          kde finance
 
     <para>If a build error occurred for a port its maintainer will be informed via
       an email so that problems which did not surface on the maintainer's machine will
-      not go unnoticed.
-
-      Port maintainers will find the
-      <link xlink:href="https://build.macports.org/waterfall">waterfall</link>
-      and the
-      <link xlink:href="https://build.macports.org/builders">builders</link>
-      views most useful since they give information about the build status and offer
-      the possibility to build one's port(s) on specific builders.</para>
+      not go unnoticed.</para>
 
     <para>Thus the buildbot helps to keep MacPorts consistent on various
       macOS versions, i.e., a maintainer does not need access to these versions anymore in
       order to assure that the port(s) maintained build without problems. Currently only
       the default port variants will be built and kept.</para>
 
+    <para>The web page at 
+      <link xlink:href="https://build.macports.org/">build.macports.org</link>
+      offers several views of the recent builds and of their success.
+      Port maintainers will find the
+      <link xlink:href="https://build.macports.org/waterfall">waterfall</link>
+      and the
+      <link xlink:href="https://build.macports.org/builders">builders</link>
+      views most useful, since they give information about the build status 
+      and offer the possibility to build one's port(s) on specific builders.
+      </para>
+
+    <para>Also, a web page at 
+      <link xlink:href="https://ports.macports.org/">ports.macports.org</link>
+      provides an alternate view of buildbot activity. 
+      Enter the name of the port you are interested in. 
+      That takes you to a summary page, which shows the success or failure of 
+      the last recorded build on each OS version. 
+      See the "Port Health" indicators near the top.
+      Click on those indicators to to see a description of the latest build on 
+      build.macports.org. 
+      Click the Build Information tab to see all recorded builds.
+      </para>
+    
   </section>
 
 </chapter>


### PR DESCRIPTION
**In no particular order:**

* Guide section 4.8. "MacPorts' buildbot" did not mention the web page at https://ports.macports.org/ at all. Add a one-paragraph summary of what this page can do for port developers to the end of the section.
* Also, the previous part of the section mentioned the "waterfall" and "builders" pages on the https://build.macports.org web page, but did not
mention the URL itself. So I added that URL.
* Re-sequence the sentences to soften the claim that these views are "most useful", since I don't think these views are as good as the ports.macports.org page.

This addresses Trac ticket #63001, "Guide: add description of web app at ports.macports.org", https://trac.macports.org/ticket/63001 .