### PR TITLE
Modify `reinplace` term definiton to make optional files arg more clear

### DIFF
--- a/guide/adoc/portfile-tcl.adoc
+++ b/guide/adoc/portfile-tcl.adoc
@@ -103,7 +103,7 @@ strsed `+string+` g/``+regex+``/``+replacement+``/ ::
 The same as the previous format, except all instances of the pattern will be replaced, not only the first (mnemonic: 'g' is for global).
 reinplace::
 Allows text specified by a regular expression to be replaced by new text, in-place (the file will be updated itself, no need to place output into a new file and rename).
- reinplace [-locale ``+locale+``] [-n] [-W ``+dir+``] [--] `+command+```+file ...+``::
+ reinplace [-locale ``+locale+``] [-n] [-W ``+dir+``] [--] `+command+```+file [``+file2 ...+``]::
 Replace text given by the regular expression portion of the command with the replacement text, in all files specified.
 +
 Use -locale to set the locale.

--- a/guide/xml/portfile-tcl.xml
+++ b/guide/xml/portfile-tcl.xml
@@ -278,7 +278,8 @@
               [-n]
               [-W <replaceable>dir</replaceable>]
               [--] <replaceable>command</replaceable>
-              <replaceable>file ...</replaceable>
+              <replaceable>file</replaceable>
+              [<replaceable>file2 ...</replaceable>]
             </term>
 
             <listitem>


### PR DESCRIPTION
Before I saw it being used that way in someone else's Portfile, I had no idea that `reinplace` is able to execute the regular expression on multiple files, because my eyes had completely ignored the `...` at the end of the term definition in the documentation. This commit makes it more clear that `...` means "additional files".