### PR TITLE
guide: MP Guide maintenance backlog

### DIFF
--- a/CONTENT.md
+++ b/CONTENT.md
@@ -1,0 +1,17 @@
+# Content List
+
+## The MacPorts Guide
+
+The [MacPorts guide](https://guide.macports.org) is the main documentation of MacPorts, providing
+information on the use of the port(1) tool, the Portfile format, and the project's policies.
+
+## This Document
+
+Provides the **content list** for _better readability_ of and _improved access_ to this folder 
+structure, including but not limited, to the  `adoc` folder particularily. For comparison to the 
+well known and established sections of the [HTML guide](https://guide.macports.org) provided
+from the sources of this repository.
+
+## TBC
+
+TBD - _work in progress - **WIP**_

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ policies.
 When a new MacPorts X.Y.0 is released, the release-X.Y branch will be merged to
 master to make the documentation available.
 
+## Content List
+
+Provides the **content list** for _better readability_ of and _improved access_ to this folder 
+structure, including but not limited, to the  `adoc` folder particularily. For comparison to the 
+well known and established sections of the [HTML guide](https://guide.macports.org) provided
+from the sources of this repository.
+
+More information at: [File: CONTENT.md](CONTENT.md) - _(WIP)_
+
 ## Building
 
 To generate  the guide, clone the macports-guide repository:


### PR DESCRIPTION
This PR is a **DRAFT** and _work in progress (**WIP**)_

The Guide provides excellent advice and is one of the main entry points for MacPorts beginners.

However, IMO quite obviously **the MP Guide needs QA** and more continuity in maintenance to the text of the guide itself.

This PR:
1. Provides the **Backlog** list - ref https://github.com/macports/macports-guide/pull/53#issuecomment-1374804353
2. The former commits are found to be misled unfortunately.

However, any consideration and further advice would be highly appreciated.