### PR TITLE
guide: startupitem: document keywords startupitem.user/startupitem.group

### DIFF
--- a/guide/xml/portfile-startupitem.xml
+++ b/guide/xml/portfile-startupitem.xml
@@ -277,6 +277,46 @@
       </varlistentry>
 
       <varlistentry>
+        <term>startupitem.user</term>
+
+        <listitem>
+          <para>(Added: MacPorts 2.7) Run the daemon via the specified user.</para>
+
+          <itemizedlist>
+            <listitem>
+              <para>Default: <option>none</option></para>
+            </listitem>
+
+            <listitem>
+              <para>Example:</para>
+
+              <programlisting>startupitem.user   my_daemon_user</programlisting>
+            </listitem>
+          </itemizedlist>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term>startupitem.group</term>
+
+        <listitem>
+          <para>(Added: MacPorts 2.7) Run the daemon via the specified group.</para>
+
+          <itemizedlist>
+            <listitem>
+              <para>Default: <option>none</option></para>
+            </listitem>
+
+            <listitem>
+              <para>Example:</para>
+
+              <programlisting>startupitem.group   my_daemon_group</programlisting>
+            </listitem>
+          </itemizedlist>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term>startupitems</term>
 
         <listitem>


### PR DESCRIPTION
Corresponding PR, for manpage update:

[PR 294 - manpages: portfile: add info for startupitem.user/startupitem.group](https://github.com/macports/macports-base/pull/294)