### PR TITLE
Show local port repository example source with nosync

### DIFF
--- a/guide/xml/portfiledev.xml
+++ b/guide/xml/portfiledev.xml
@@ -732,7 +732,7 @@ variant sqlite description {Build sqlite support} {
         <para>Insert a URL pointing to your local repository location before
         the rsync URL as shown.</para>
 
-        <programlisting>file:///Users/julesverne/ports
+        <programlisting>file:///Users/julesverne/ports [nosync]
 rsync://rsync.macports.org/macports/release/tarballs/ports.tar [default]
 </programlisting>
 


### PR DESCRIPTION
I believe it would make sense to change the example for the local port repository to prevent the source from syncing during 'port sync'