### PR TITLE
Update installing.xml: add missing`.zprofile`

### DIFF
--- a/guide/xml/installing.xml
+++ b/guide/xml/installing.xml
@@ -494,8 +494,8 @@
             environment manually using the rules as a guide.</para>
 
         <para>Depending on your shell and which configuration files already exist, the installer may use
-            <filename>.profile</filename>, <filename>.bash_login</filename>, <filename>.bash_profile</filename>,
-            <filename>.tcshrc</filename>, or <filename>.cshrc</filename>.</para>
+            <filename>.zprofile</filename>, <filename>.profile</filename>, <filename>.bash_login</filename>, 
+            <filename>.bash_profile</filename>, <filename>.tcshrc</filename>, or <filename>.cshrc</filename>.</para>
 
         <section xml:id="installing.shell.postflight">
             <title>The Postflight Script</title>


### PR DESCRIPTION
The install guide lists a number of shell config files that may end up getting modified by the postflight script. But the one file that actually got modified on a recent install on macOS 14 on an M1 mac is actually missing: `.zprofile`

See https://apple.stackexchange.com/questions/467713/where-does-macports-add-itself-to-path