### PR TITLE
Two corrections for variant names

### DIFF
--- a/guide/xml/portfile-variants.xml
+++ b/guide/xml/portfile-variants.xml
@@ -20,8 +20,9 @@
     <code>default_variants</code> (see below).</para>
 
     <note>
-      <para>Variant names may contain only letters, numbers and underscore
-      characters. In particular, the hyphen is not a valid character in
+      <para>Variant names may contain only the characters A-Z, a-z,
+      0-9, underscore <quote>_</quote>, and period <quote>.</quote>. 
+      In particular, the hyphen is not a valid character in
       variant names because it would conflict with the notation for deselecting
       a variant.</para>
     </note>

--- a/guide/xml/portfiledev.xml
+++ b/guide/xml/portfiledev.xml
@@ -448,9 +448,9 @@ variant sqlite description {Build sqlite support} {
 }</programlisting>
 
       <note>
-        <para>Variant names may contain only the characters A-Z, a-z, and the
-        underscore character <quote>_</quote>. Therefore, take care to never
-        use hyphens in variant names.</para>
+        <para>Variant names may contain only the characters A-Z, a-z,
+        0-9, underscore <quote>_</quote>, and period <quote>.</quote>. 
+        Therefore, take care to never use hyphens in variant names.</para>
       </note>
 
       <para>In the example variant declaration below, the configure argument


### PR DESCRIPTION
Update guide to match code for allowed characters in variant names.